### PR TITLE
AddedWarningForInteractiveAuthonMacorLinux

### DIFF
--- a/PSCloudPC/Public/Connect-Windows365.ps1
+++ b/PSCloudPC/Public/Connect-Windows365.ps1
@@ -46,6 +46,17 @@ function Connect-Windows365 {
         
         switch ($Authtype) {
             Interactive {
+
+                $environment = Get-ChildItem -Path C:\Windows -ErrorAction SilentlyContinue
+
+                If ($null -eq $environment) {
+                    Write-Error "Using Powershell Core on Mac or Linux, please use the DeviceCode or ServicePrincipal Authentication"
+                    Break
+                }
+                else {
+                    Write-Verbose "Using Windows Powershell Core, continue with the script"
+                }
+
                 Write-Verbose "Use Interactive Authentication"
                 Write-Verbose "Using Windows Powershell"
                 # Add required assemblies


### PR DESCRIPTION
Added a warning for using interactive authentication on Mac or Linux because the interactive authentication uses a Windows builtin feature that doesn't work on mac or linux