### PR TITLE
Bumped upload/download-artifact to version v4

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -91,12 +91,12 @@ jobs:
           repository: ''
           path: 'drop'
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: PSCloudPC
           path: drop
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v2.1.0
+        uses: actions/download-artifact@v4
         with:
           name: PSCloudPC
       - name: Publishing module


### PR DESCRIPTION
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.