### PR TITLE
Feature/pester tests for connect disconnect windows365

### DIFF
--- a/Src/Public/Connect-Windows365.ps1
+++ b/Src/Public/Connect-Windows365.ps1
@@ -154,11 +154,6 @@ function Connect-Windows365 {
 
                 Write-Verbose "Using Token Authentication"
 
-                if (-not $Token) {
-                    Write-Error "Token is required for Token Authentication"
-                    return
-                }
-
                 $script:Authtime = [System.DateTime]::UtcNow
                 $script:Authtoken = $Token
                 $script:Authheader = @{Authorization = "Bearer $($Token)" }

--- a/Src/Public/Export-CPCProvisioningPolicy.ps1
+++ b/Src/Public/Export-CPCProvisioningPolicy.ps1
@@ -16,7 +16,7 @@ function Export-CPCProvisioningPolicy {
         [parameter(Mandatory = $true, ParameterSetName = "Name")]
         [string]$OutputFolder
     )
-    
+
     Begin {
         Get-TokenValidity
 
@@ -27,7 +27,7 @@ function Export-CPCProvisioningPolicy {
             break
         }
     }
-    
+
     Process {
 
         $url = "https://graph.microsoft.com/$script:MSGraphVersion/deviceManagement/virtualEndpoint/provisioningPolicies/$($Policy.id)/"
@@ -36,7 +36,7 @@ function Export-CPCProvisioningPolicy {
 
         try {
             $result = Invoke-WebRequest -uri $url -Method GET -Headers $script:authHeader
-    
+
             if ($null -eq $result) {
                 Write-Error "No Provisioning Policy returned"
                 break
@@ -52,5 +52,5 @@ function Export-CPCProvisioningPolicy {
             Throw $_.Exception.Message
         }
     }
-    
+
 }

--- a/Tests/Connect-Windows365.tests.ps1
+++ b/Tests/Connect-Windows365.tests.ps1
@@ -1,0 +1,56 @@
+<#
+This file tests the Disconnect-Windows365 function by using Pester
+#>
+
+
+$modulename = 'PSCloudPC'
+
+BeforeAll {
+  # Import the module - correct relative path from Tests folder
+  Import-Module "./PSCloudPC/Src/PSCloudPC.psm1" -Force
+
+
+  Function Set-GraphVersion {
+    # This function sets the Graph API version to beta
+    Write-Verbose "Graph API version set to beta"
+  }
+
+  Function Connect-MgGraph {
+    # Mock function to simulate connection to Microsoft Graph
+    Write-Verbose "Mocked Connect-MgGraph"
+  }
+
+  Function Invoke-MgGraphRequest {
+    # Mock function to simulate invoking a Microsoft Graph API request
+    Write-Verbose "Mocked Invoke-MgGraphRequest"
+  }
+}
+
+Describe "Connect-Windows365" {
+
+  It "Should Connect to Windows 365 using Interactive Authentication" {
+
+    Mock -CommandName Set-GraphVersion -MockWith {
+      Write-Host "Setting Graph API version to beta"
+      $script:GraphVersion = "beta"
+    }
+
+    Mock -CommandName Connect-MgGraph -MockWith { $null }
+
+    Mock -CommandName Invoke-MgGraphRequest -MockWith {
+
+      Write-Output "Mocked Invoke-MgGraphRequest"
+      $script:GraphVersion = "beta"
+      $script:Authtoken = "mocked_token"
+      $script:Authheader = @{ Authorization = "Bearer mocked_token" }
+      $script:Authtime = [System.DateTime]::UtcNow
+    }
+
+  Connect-Windows365
+
+  $script:GraphVersion | Should -Be "beta"
+  $script:Authtoken | Should -Not -BeNullOrEmpty
+  $script:Authheader | Should -Not -BeNullOrEmpty
+  $script:Authtime | Should -Not -BeNullOrEmpty
+}
+}

--- a/Tests/Disconnect-Windows365.tests.ps1
+++ b/Tests/Disconnect-Windows365.tests.ps1
@@ -7,32 +7,32 @@ $modulename = 'PSCloudPC'
 BeforeAll {
     # Import the module - correct relative path from Tests folder
     Import-Module "./PSCloudPC/Src/PSCloudPC.psm1" -Force
+    Import-Module Microsoft.Graph.Authentication -Force
 
     # Mock Disconnect-MgGraph to prevent actual disconnection during tests
     Mock -CommandName Disconnect-MgGraph -MockWith { }
 
+    Function Get-MGContext {
+        return @{
+            ClientId            = [guid]::NewGuid().ToString()
+            TenantId            = [guid]::NewGuid().ToString()
+            Scopes              = @('AccessReview.Read.All', 'Agreement.Read.All')
+            AuthType            = 'Delegated'
+            TokenCredentialType = 'InteractiveBrowser'
+            Account             = 'admin@contoso.com'
+            AppName             = 'Microsoft Graph Command Line Tools'
+            ContextScope        = 'CurrentUser'
+            Environment         = 'Global'
+        }
+    }
 }
 
 Describe "Disconnect-Windows365" {
 
     It "Should disconnect from Windows 365 and clear the token cache when connected" {
 
-        Mock -CommandName Get-MgContext -MockWith {
-            $Context = @{
-                ClientId            = [guid]::NewGuid().ToString()
-                TenantId            = [guid]::NewGuid().ToString()
-                Scopes              = @('AccessReview.Read.All', 'Agreement.Read.All')
-                AuthType            = 'Delegated'
-                TokenCredentialType = 'InteractiveBrowser'
-                Account             = 'admin@contoso.com'
-                AppName             = 'Microsoft Graph Command Line Tools'
-                ContextScope        = 'CurrentUser'
-                Environment         = 'Global'
-            }
-            $Context
-        } -ModuleName $modulename
         # Act
-        Disconnect-Windows365
+        Disconnect-Windows365 -Verbose
 
         # Assert
         $script:Authtime | Should -BeNullOrEmpty


### PR DESCRIPTION
Wrote pester test for Connect-Windows365. Removed unnecessary code. If statement for token check is unnecessary when the parameter token in the parameterset is mandatory