### PR TITLE
Add SelfServiceEnabled parameter to Update-CPCUserSettingsPolicy

### DIFF
--- a/PSCloudPc/Public/Update-CPCUserSettingsPolicy.ps1
+++ b/PSCloudPc/Public/Update-CPCUserSettingsPolicy.ps1
@@ -17,12 +17,17 @@ function Update-CPCUserSettingsPolicy {
     Frequency (in hours) at which restore point snapshots are captured. Valid values: 4, 6, 12, 16, 24.
     .PARAMETER DisableRestartPrompts
     When $true, disables the restart prompts shown to the user on the Cloud PC (notificationSetting).
+    .PARAMETER SelfServiceEnabled
+    Allow or prevent targeted users from performing self-service actions (e.g. upgrading their Cloud PC)
+    from within the Windows 365 app. Uses the Graph beta selfServiceEnabled property.
     .EXAMPLE
     Update-CPCUserSettingsPolicy -Name "Your Settings Policy" -LocalAdminEnabled $true
     .EXAMPLE
     Update-CPCUserSettingsPolicy -Name "Your Settings Policy" -LocalAdminEnabled $false -ResetEnabled $true -UserRestoreEnabled $true -UserRestoreFrequency 6
     .EXAMPLE
     Update-CPCUserSettingsPolicy -Name "Your Settings Policy" -DisableRestartPrompts $true
+    .EXAMPLE
+    Update-CPCUserSettingsPolicy -Name "Your Settings Policy" -SelfServiceEnabled $true
     .NOTES
     API reference: https://learn.microsoft.com/en-us/graph/api/cloudpcusersetting-update
     #>
@@ -45,7 +50,10 @@ function Update-CPCUserSettingsPolicy {
         [string]$UserRestoreFrequency,
 
         [Parameter(Mandatory = $false)]
-        [bool]$DisableRestartPrompts
+        [bool]$DisableRestartPrompts,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$SelfServiceEnabled
     )
 
     Begin {
@@ -95,6 +103,10 @@ function Update-CPCUserSettingsPolicy {
             $params['notificationSetting'] = @{
                 restartPromptsDisabled = $DisableRestartPrompts
             }
+        }
+
+        If ($PSBoundParameters.ContainsKey('SelfServiceEnabled')) {
+            $params['selfServiceEnabled'] = $SelfServiceEnabled
         }
 
         Write-Verbose "Params: $($params | ConvertTo-Json -Depth 10)"


### PR DESCRIPTION
## Summary

Adds the `-SelfServiceEnabled` boolean parameter to `Update-CPCUserSettingsPolicy`, addressing feature request #87.

### Problem

The `cloudPcUserSetting` resource has a `selfServiceEnabled` property in the Microsoft Graph API (beta), which controls whether users can perform self-service actions (such as upgrading their Cloud PC) from within the Windows 365 app.

- `Get-CPCUserSettingsPolicy` already returns `selfServiceEnabled` in its output
- `Set-CPCCrossRegionDisasterRecovery` already preserves `selfServiceEnabled` when patching
- But there was no way to actively set/change the value via `Update-CPCUserSettingsPolicy`

### Solution

Added `-SelfServiceEnabled` boolean parameter to `Update-CPCUserSettingsPolicy`. When provided, the value is included in the PATCH body sent to the Graph API.

### How to test

```powershell
# Enable self-service
Update-CPCUserSettingsPolicy -Name "My Policy" -SelfServiceEnabled $true

# Disable self-service
Update-CPCUserSettingsPolicy -Name "My Policy" -SelfServiceEnabled $false

# Verify via Get
$policy = Get-CPCUserSettingsPolicy -Name "My Policy"
$policy.selfServiceEnabled
```

### API reference
- https://learn.microsoft.com/en-us/graph/api/cloudpcusersetting-update

Closes #87