### PR TITLE
Fix Invoke-CPCReprovision: correct API endpoint + add -OsVersion and -UserAccountType params

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCReprovision.ps1
+++ b/PSCloudPc/Public/Invoke-CPCReprovision.ps1
@@ -1,39 +1,79 @@
 function Invoke-CPCReprovision {
     <#
     .SYNOPSIS
-    Restore a Cloud PC to a certain point in time with
+    Reprovision a Cloud PC
     .DESCRIPTION
-    The function will restore a Cloud PC to a certain point in time
+    The function will reprovision a Cloud PC using the Microsoft Graph v1.0 API.
+    Optionally override the OS version (Windows 10 or 11) and the user account type
+    (standard user or local administrator) for the reprovisioned Cloud PC.
     .PARAMETER Name
     Enter the Cloud PC display name
+    .PARAMETER OsVersion
+    Optional. The operating system version to provision. Valid values: 'windows10', 'windows11'.
+    When omitted the tenant/policy default is used.
+    .PARAMETER UserAccountType
+    Optional. The local account type for the user on the reprovisioned Cloud PC.
+    Valid values: 'standardUser', 'administrator'.
+    When omitted the tenant/policy default is used.
     .EXAMPLE
     Invoke-CPCReprovision -Name "CloudPC01"
+    .EXAMPLE
+    Invoke-CPCReprovision -Name "CloudPC01" -OsVersion windows11 -UserAccountType standardUser
+    .NOTES
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-reprovision
     #>
-    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $false, ParameterSetName = 'Name')]
-        [string]$Name
+        [parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [parameter(Mandatory = $false)]
+        [ValidateSet('windows10', 'windows11')]
+        [string]$OsVersion,
+
+        [parameter(Mandatory = $false)]
+        [ValidateSet('standardUser', 'administrator')]
+        [string]$UserAccountType
     )
     
     begin {
         Get-TokenValidity
         
         $CloudPC = Get-CloudPC -name $Name
-        
-        $url = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($CloudPC.managedDeviceId)/reprovisionCloudPc"
+
+        if ($null -eq $CloudPC) {
+            Throw "No Cloud PC found with name $Name"
+            return
+        }
+
+        $url = "https://graph.microsoft.com/$script:MSGraphVersion/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/reprovision"
 
         Write-Verbose "URL: $url"
-        }
+    }
 
     Process {
 
-        try {
-            Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
-            Write-Output "Cloud PC $($CloudPC.displayName) reprovisioned"
+        $params = @{}
+
+        if ($PSBoundParameters.ContainsKey('OsVersion')) {
+            $params['osVersion'] = $OsVersion
         }
-        catch {
-            Throw $_.Exception.Message
+
+        if ($PSBoundParameters.ContainsKey('UserAccountType')) {
+            $params['userAccountType'] = $UserAccountType
         }
-    
+
+        $body = $params | ConvertTo-Json -Depth 5
+
+        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Reprovision Cloud PC")) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -Body $body -ContentType "application/json"
+                Write-Output "Cloud PC $($CloudPC.displayName) reprovision initiated"
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix `Invoke-CPCReprovision` which was calling a legacy beta endpoint that no longer reflects the current Graph API for Cloud PC reprovisioning.

## Problem

The function was using:
```
POST /beta/deviceManagement/managedDevices/{managedDeviceId}/reprovisionCloudPc
```

This is the old `managedDevices` path, which is inconsistent with all other `Invoke-CPC*` functions in the module and routes through the generic device management endpoint rather than the Virtual Endpoint API. The correct v1.0 endpoint is:
```
POST /deviceManagement/virtualEndpoint/cloudPCs/{id}/reprovision
```

This same class of bug was previously fixed in `Invoke-CPCRestore` (see PR #95).

## Changes

- **Corrected API endpoint** from legacy `beta/deviceManagement/managedDevices/{managedDeviceId}/reprovisionCloudPc` to `$script:MSGraphVersion/deviceManagement/virtualEndpoint/cloudPCs/{id}/reprovision` (uses the module's configured API version)
- **Added `-OsVersion` parameter** (`windows10` | `windows11`) — allows overriding the OS version on the reprovisioned Cloud PC; uses tenant/policy default when omitted
- **Added `-UserAccountType` parameter** (`standardUser` | `administrator`) — allows overriding the local account type on the reprovisioned Cloud PC; uses tenant/policy default when omitted
- **Added `SupportsShouldProcess`** (`-WhatIf` / `-Confirm` support), consistent with other action functions
- **Fixed `Mandatory=$false` → `Mandatory=$true`** on `-Name` — was inconsistent with all other `Invoke-CPC*` functions; a reprovision without a target name makes no sense
- **Added null guard** after `Get-CloudPC` to fail fast with a clear error if the Cloud PC is not found
- **Fixed `.SYNOPSIS` / `.DESCRIPTION`** which were incorrectly copied from `Invoke-CPCRestore` and described a restore operation

## How to Test

```powershell
# Basic reprovision (uses tenant defaults)
Invoke-CPCReprovision -Name "CloudPC01"

# With -WhatIf (should not trigger the API call)
Invoke-CPCReprovision -Name "CloudPC01" -WhatIf

# With OS override
Invoke-CPCReprovision -Name "CloudPC01" -OsVersion windows11 -UserAccountType standardUser
```

Verify the API call goes to `virtualEndpoint/cloudPCs/{id}/reprovision` with the correct Cloud PC `id` (not `managedDeviceId`).

## API Reference

- https://learn.microsoft.com/en-us/graph/api/cloudpc-reprovision?view=graph-rest-1.0