### PR TITLE
Add Invoke-CPCTroubleshoot function for Cloud PC health diagnostics

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCTroubleshoot.ps1
+++ b/PSCloudPc/Public/Invoke-CPCTroubleshoot.ps1
@@ -1,0 +1,51 @@
+function Invoke-CPCTroubleshoot {
+    <#
+        .SYNOPSIS
+        Triggers a troubleshoot action on a Cloud PC
+        .DESCRIPTION
+        The function triggers the troubleshoot action on a specific Cloud PC. This initiates a
+        health check and session host inspection on the target Cloud PC, helping administrators
+        diagnose connectivity, configuration, and health issues without reprovisioning.
+        Use Get-CloudPC to find Cloud PC names. The action returns 204 No Content on success.
+        .PARAMETER Name
+        Enter the display name of the Cloud PC to troubleshoot
+        .EXAMPLE
+        Invoke-CPCTroubleshoot -Name "CloudPC01"
+        .EXAMPLE
+        Invoke-CPCTroubleshoot -Name "CloudPC01" -WhatIf
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        $CloudPC = Get-CloudPC -Name $Name
+
+        if ($null -eq $CloudPC) {
+            Write-Error "Cloud PC '$Name' not found"
+            return
+        }
+
+        $url = "https://graph.microsoft.com/$script:MSGraphVersion/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/troubleshoot"
+        Write-Verbose "Troubleshoot URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Triggering troubleshoot on Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id))"
+
+        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Troubleshoot Cloud PC")) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
+                Write-Output "Troubleshoot action triggered for Cloud PC '$($CloudPC.displayName)'"
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Invoke-CPCTroubleshoot` function that triggers the built-in troubleshoot action on a Cloud PC via the Microsoft Graph v1.0 API.

The troubleshoot action checks the health status of the Cloud PC and its session host, helping administrators diagnose connectivity, configuration, and health issues without having to reprovision.

## API Reference

- **Endpoint:** `POST /deviceManagement/virtualEndpoint/cloudPCs/{cloudPCId}/troubleshoot`
- **API version:** Graph v1.0 (generally available)
- **Permission required:** `CloudPC.ReadWrite.All`
- **Response:** `204 No Content` on success
- **Docs:** https://learn.microsoft.com/en-us/graph/api/cloudpc-troubleshoot

## Changes

- Added `PSCloudPc/Public/Invoke-CPCTroubleshoot.ps1`

## Usage

```powershell
# Trigger troubleshoot on a specific Cloud PC
Invoke-CPCTroubleshoot -Name "CloudPC01"

# Preview what would happen (WhatIf support)
Invoke-CPCTroubleshoot -Name "CloudPC01" -WhatIf
```

## How to Test

1. Connect to Windows 365 with `Connect-Windows365`
2. Run `Get-CloudPC` to find a valid Cloud PC name
3. Run `Invoke-CPCTroubleshoot -Name "<CloudPCName>" -WhatIf` -- should show target without executing
4. Run `Invoke-CPCTroubleshoot -Name "<CloudPCName>"` -- should return confirmation message
5. Verify in the Intune/Windows 365 portal that a troubleshoot action was triggered

## Notes

- Follows the same code pattern as `Invoke-CPCReboot` and `Invoke-CPCReprovision`
- Uses `SupportsShouldProcess` for `-WhatIf` / `-Confirm` support
- Null-guards the Cloud PC lookup before attempting the API call
- No request body is required per the API spec
- Manifest (`PSCloudPc.psd1`) is intentionally not modified -- per maintainer preference