### PR TITLE
Add Invoke-CPCPowerOn and Invoke-CPCPowerOff for W365 Frontline power management

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
@@ -1,0 +1,59 @@
+function Invoke-CPCPowerOff {
+    <#
+    .SYNOPSIS
+    Powers off a Windows 365 Frontline Cloud PC
+    .DESCRIPTION
+    The function powers off a specific Windows 365 Frontline Cloud PC via the
+    Microsoft Graph beta API. After the Cloud PC is powered off, it is deallocated
+    and licenses are revoked immediately.
+
+    Note: This action applies to Windows 365 Frontline Cloud PCs only.
+    Only IT admin users can perform this action. Returns 204 No Content on success.
+    .PARAMETER Name
+    Enter the display name of the Cloud PC to power off
+    .EXAMPLE
+    Invoke-CPCPowerOff -Name "CloudPC01"
+    .EXAMPLE
+    Invoke-CPCPowerOff -Name "CloudPC01" -WhatIf
+    .NOTES
+    Requires CloudPC.ReadWrite.All permission (delegated or application).
+    This action uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    begin {
+        Get-TokenValidity
+
+        $CloudPC = Get-CloudPC -Name $Name
+
+        if ($null -eq $CloudPC) {
+            Throw "No Cloud PC found with name '$Name'"
+            return
+        }
+
+        # powerOff is a beta-only API; always use beta endpoint
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOff"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Powering off Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id))"
+
+        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Power off Cloud PC")) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
+                Write-Output "Cloud PC '$($CloudPC.displayName)' power off initiated"
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}

--- a/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
@@ -1,0 +1,59 @@
+function Invoke-CPCPowerOn {
+    <#
+    .SYNOPSIS
+    Powers on a Windows 365 Frontline Cloud PC
+    .DESCRIPTION
+    The function powers on a specific Windows 365 Frontline Cloud PC via the
+    Microsoft Graph beta API. After the Cloud PC is powered on, it is allocated
+    to a user and licenses are assigned immediately.
+
+    Note: This action applies to Windows 365 Frontline Cloud PCs only.
+    Only IT admin users can perform this action. Returns 204 No Content on success.
+    .PARAMETER Name
+    Enter the display name of the Cloud PC to power on
+    .EXAMPLE
+    Invoke-CPCPowerOn -Name "CloudPC01"
+    .EXAMPLE
+    Invoke-CPCPowerOn -Name "CloudPC01" -WhatIf
+    .NOTES
+    Requires CloudPC.ReadWrite.All permission (delegated or application).
+    This action uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    begin {
+        Get-TokenValidity
+
+        $CloudPC = Get-CloudPC -Name $Name
+
+        if ($null -eq $CloudPC) {
+            Throw "No Cloud PC found with name '$Name'"
+            return
+        }
+
+        # powerOn is a beta-only API; always use beta endpoint
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOn"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Powering on Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id))"
+
+        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Power on Cloud PC")) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
+                Write-Output "Cloud PC '$($CloudPC.displayName)' power on initiated"
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new cmdlets for Windows 365 **Frontline** Cloud PC power management:

- `Invoke-CPCPowerOn` — powers on a Frontline Cloud PC, allocating it to a user and assigning licenses immediately
- `Invoke-CPCPowerOff` — powers off a Frontline Cloud PC, deallocating it and revoking licenses immediately

Both use the Microsoft Graph **beta** endpoint (no v1.0 equivalent exists yet). The module already uses beta in `Connect-Windows365` (`Set-GraphVersion`) for all calls, so this follows established practice.

---

## API Reference

- `POST /beta/deviceManagement/virtualEndpoint/cloudPCs/{id}/powerOn`
  https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
- `POST /beta/deviceManagement/virtualEndpoint/cloudPCs/{id}/powerOff`
  https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff

**Required permission:** `CloudPC.ReadWrite.All` (delegated or application)

---

## Files changed

| File | Change |
|------|--------|
| `PSCloudPc/Public/Invoke-CPCPowerOn.ps1` | New function |
| `PSCloudPc/Public/Invoke-CPCPowerOff.ps1` | New function |

Both functions follow the existing module conventions:
- `Get-TokenValidity` in `begin` block
- `Get-CloudPC -Name` lookup with null guard + `Throw`
- `SupportsShouldProcess` / `-WhatIf` support
- Hardcoded `beta` endpoint path (noted in SYNOPSIS and NOTES)
- `try/catch` with `Throw $_.Exception.Message`

---

## How to test

```powershell
Connect-Windows365

# WhatIf preview (safe, no changes made)
Invoke-CPCPowerOn  -Name "MyFrontlineCloudPC" -WhatIf
Invoke-CPCPowerOff -Name "MyFrontlineCloudPC" -WhatIf

# Power on a Frontline Cloud PC (allocates user + assigns license)
Invoke-CPCPowerOn -Name "MyFrontlineCloudPC"

# Power off a Frontline Cloud PC (deallocates + revokes license)
Invoke-CPCPowerOff -Name "MyFrontlineCloudPC"
```

Returns 204 No Content on success; a confirmation string is written to stdout.

---

> **Note for maintainer:** `PSCloudPc.psd1` `FunctionsToExport` will need `Invoke-CPCPowerOn` and `Invoke-CPCPowerOff` added. Additionally, the recently merged `Invoke-CPCChangeUserAccountType`, `Invoke-CPCCreateSnapshot`, and `Invoke-CPCTroubleshoot` are also missing from `FunctionsToExport` — this is likely the root cause of issue #104 (the function exists in `Public/` and is dot-sourced by the psm1, but when `FunctionsToExport` is an explicit list, PowerShell honours the manifest and the function appears unavailable).
