### PR TITLE
Fix Invoke-CPCChangeUserAccountType: handle empty result + add -CloudPCId parameter (closes #104)

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCChangeUserAccountType.ps1
+++ b/PSCloudPc/Public/Invoke-CPCChangeUserAccountType.ps1
@@ -7,25 +7,38 @@ function Invoke-CPCChangeUserAccountType {
     standard user and local administrator using the Microsoft Graph beta API.
     Use this to elevate a user to local admin for troubleshooting or to demote
     an administrator back to a standard user for compliance reasons.
+
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
     .PARAMETER Name
-    Enter the display name of the Cloud PC
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
     .PARAMETER UserAccountType
     The account type to set for the user on the Cloud PC.
     Valid values: 'standardUser', 'administrator'.
     .EXAMPLE
-    Invoke-CPCChangeUserAccountType -Name "CloudPC01" -UserAccountType administrator
+    Invoke-CPCChangeUserAccountType -Name "CPC-User-XXXX" -UserAccountType administrator
     .EXAMPLE
-    Invoke-CPCChangeUserAccountType -Name "CloudPC01" -UserAccountType standardUser
+    Invoke-CPCChangeUserAccountType -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd" -UserAccountType standardUser
+    .EXAMPLE
+    Invoke-CPCChangeUserAccountType -Name "CPC-User-XXXX" -UserAccountType administrator -WhatIf
     .NOTES
     Requires CloudPC.ReadWrite.All permission (delegated or application).
     This action uses the Microsoft Graph beta endpoint.
     API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-changeuseraccounttype
     #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [ValidateNotNullOrEmpty()]
         [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('standardUser', 'administrator')]
@@ -35,29 +48,40 @@ function Invoke-CPCChangeUserAccountType {
     begin {
         Get-TokenValidity
 
-        $CloudPC = Get-CloudPC -Name $Name
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
 
-        if ($null -eq $CloudPC) {
-            Throw "No Cloud PC found with name '$Name'"
-            return
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId = $CloudPCId
+            $targetName = $CloudPCId
         }
 
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/changeUserAccountType"
+        # changeUserAccountType is beta-only; no v1.0 equivalent exists
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/changeUserAccountType"
 
         Write-Verbose "URL: $url"
     }
 
     Process {
-        $params = @{
+        $body = @{
             userAccountType = $UserAccountType
         } | ConvertTo-Json -Depth 10
 
-        Write-Verbose "Changing user account type on Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id)) to '$UserAccountType'"
+        Write-Verbose "Changing user account type on Cloud PC '$targetName' (id: $targetId) to '$UserAccountType'"
 
-        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Change user account type to '$UserAccountType'")) {
+        if ($PSCmdlet.ShouldProcess($targetName, "Change user account type to '$UserAccountType'")) {
             try {
-                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -Body $params -ContentType "application/json"
-                Write-Output "Cloud PC '$($CloudPC.displayName)' user account type changed to '$UserAccountType'"
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -Body $body -ContentType "application/json"
+                Write-Output "Cloud PC '$targetName' user account type changed to '$UserAccountType'"
             }
             catch {
                 Throw $_.Exception.Message


### PR DESCRIPTION
## Summary

Fixes issue #104 — `Invoke-CPCChangeUserAccountType` was reported as not working on the develop branch.

### Root cause

The original function checked `if ($null -eq $CloudPC)` to detect a failed lookup, but `Get-CloudPC` returns an **empty array** `@()` (not `$null`) when no match is found. An empty array is never `$null` in PowerShell, so the guard silently passed and `$CloudPC.id` evaluated to `$null`, producing an invalid URL:

```
https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs//changeUserAccountType
```

This caused a `404` from the Graph API, surfaced only as a generic exception message.

### Fixes applied

1. **Corrected null guard**: Changed to `if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0)` so empty-array returns are properly caught and a descriptive error is thrown.
2. **Defensive first-item selection**: Added `@($CloudPC)[0]` to guarantee a single object is used even if multiple results are returned.
3. **New `-CloudPCId` parameter set**: Users who already know the Cloud PC object ID (e.g. from `Get-CloudPC | Select id`) can now pass it directly, bypassing the name lookup entirely. This is more reliable in automation scenarios.
4. **Clarified `-Name` documentation**: The help now states the parameter expects the **managed device name** (as returned by `Get-CloudPC`) to avoid confusion with the display name shown in the admin portal.

## Changes

- `PSCloudPc/Public/Invoke-CPCChangeUserAccountType.ps1`
  - Added `DefaultParameterSetName = "Name"` on `[CmdletBinding]`
  - Added `[Parameter(Mandatory, ParameterSetName = "Id")] [string]$CloudPCId` parameter
  - Fixed empty-array null guard
  - Added `@($CloudPC)[0]` defensive unwrap
  - Renamed internal variable `$params` → `$body` for consistency with sibling functions
  - Updated comment-based help with corrected parameter descriptions and an additional example

## How to test

```powershell
# Connect first
Connect-Windows365

# Get the managed device name
$cpc = Get-CloudPC | Where-Object { $_.userPrincipalName -eq "john@contoso.com" }

# Elevate via name
Invoke-CPCChangeUserAccountType -Name $cpc.managedDeviceName -UserAccountType administrator

# Or use the ID directly (more robust in automation)
Invoke-CPCChangeUserAccountType -CloudPCId $cpc.id -UserAccountType standardUser

# WhatIf preview
Invoke-CPCChangeUserAccountType -Name $cpc.managedDeviceName -UserAccountType administrator -WhatIf
```

## API reference

- https://learn.microsoft.com/en-us/graph/api/cloudpc-changeuseraccounttype
- Requires `CloudPC.ReadWrite.All` (delegated or application)
- Returns `204 No Content` on success

> **Note:** The manifest (`PSCloudPC.psd1`) is intentionally not modified per maintainer preference.