### PR TITLE
Fix Invoke-CPCPowerOn/Off: handle array result from Get-CloudPC, add -CloudPCId parameter (closes #107)

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
@@ -7,49 +7,72 @@ function Invoke-CPCPowerOff {
     Microsoft Graph beta API. After the Cloud PC is powered off, it is deallocated
     and licenses are revoked immediately.
 
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+
     Note: This action applies to Windows 365 Frontline Cloud PCs only.
     Only IT admin users can perform this action. Returns 204 No Content on success.
     .PARAMETER Name
-    Enter the display name of the Cloud PC to power off
+    The managed device name of the Cloud PC to power off. Use Get-CloudPC to find
+    Cloud PC names. Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC to power off. Use Get-CloudPC to find
+    Cloud PC IDs. Mutually exclusive with -Name.
     .EXAMPLE
-    Invoke-CPCPowerOff -Name "CloudPC01"
+    Invoke-CPCPowerOff -Name "CPC-User-XXXX"
     .EXAMPLE
-    Invoke-CPCPowerOff -Name "CloudPC01" -WhatIf
+    Invoke-CPCPowerOff -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .EXAMPLE
+    Invoke-CPCPowerOff -Name "CPC-User-XXXX" -WhatIf
     .NOTES
     Requires CloudPC.ReadWrite.All permission (delegated or application).
     This action uses the Microsoft Graph beta endpoint.
     API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff
     #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [ValidateNotNullOrEmpty()]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
     )
 
     begin {
         Get-TokenValidity
 
-        $CloudPC = Get-CloudPC -Name $Name
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
 
-        if ($null -eq $CloudPC) {
-            Throw "No Cloud PC found with name '$Name'"
-            return
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId   = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId   = $CloudPCId
+            $targetName = $CloudPCId
         }
 
-        # powerOff is a beta-only API; always use beta endpoint
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOff"
+        # powerOff is a beta-only API; always use /beta/ path
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/powerOff"
 
         Write-Verbose "URL: $url"
     }
 
     Process {
-        Write-Verbose "Powering off Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id))"
+        Write-Verbose "Powering off Cloud PC '$targetName' (id: $targetId)"
 
-        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Power off Cloud PC")) {
+        if ($PSCmdlet.ShouldProcess($targetName, "Power off Cloud PC")) {
             try {
                 Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
-                Write-Output "Cloud PC '$($CloudPC.displayName)' power off initiated"
+                Write-Output "Cloud PC '$targetName' power off initiated"
             }
             catch {
                 Throw $_.Exception.Message

--- a/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
@@ -7,49 +7,72 @@ function Invoke-CPCPowerOn {
     Microsoft Graph beta API. After the Cloud PC is powered on, it is allocated
     to a user and licenses are assigned immediately.
 
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+
     Note: This action applies to Windows 365 Frontline Cloud PCs only.
     Only IT admin users can perform this action. Returns 204 No Content on success.
     .PARAMETER Name
-    Enter the display name of the Cloud PC to power on
+    The managed device name of the Cloud PC to power on. Use Get-CloudPC to find
+    Cloud PC names. Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC to power on. Use Get-CloudPC to find
+    Cloud PC IDs. Mutually exclusive with -Name.
     .EXAMPLE
-    Invoke-CPCPowerOn -Name "CloudPC01"
+    Invoke-CPCPowerOn -Name "CPC-User-XXXX"
     .EXAMPLE
-    Invoke-CPCPowerOn -Name "CloudPC01" -WhatIf
+    Invoke-CPCPowerOn -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .EXAMPLE
+    Invoke-CPCPowerOn -Name "CPC-User-XXXX" -WhatIf
     .NOTES
     Requires CloudPC.ReadWrite.All permission (delegated or application).
     This action uses the Microsoft Graph beta endpoint.
     API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
     #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [ValidateNotNullOrEmpty()]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
     )
 
     begin {
         Get-TokenValidity
 
-        $CloudPC = Get-CloudPC -Name $Name
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
 
-        if ($null -eq $CloudPC) {
-            Throw "No Cloud PC found with name '$Name'"
-            return
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId   = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId   = $CloudPCId
+            $targetName = $CloudPCId
         }
 
-        # powerOn is a beta-only API; always use beta endpoint
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOn"
+        # powerOn is a beta-only API; always use /beta/ path
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/powerOn"
 
         Write-Verbose "URL: $url"
     }
 
     Process {
-        Write-Verbose "Powering on Cloud PC '$($CloudPC.displayName)' (id: $($CloudPC.id))"
+        Write-Verbose "Powering on Cloud PC '$targetName' (id: $targetId)"
 
-        if ($PSCmdlet.ShouldProcess($CloudPC.displayName, "Power on Cloud PC")) {
+        if ($PSCmdlet.ShouldProcess($targetName, "Power on Cloud PC")) {
             try {
                 Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
-                Write-Output "Cloud PC '$($CloudPC.displayName)' power on initiated"
+                Write-Output "Cloud PC '$targetName' power on initiated"
             }
             catch {
                 Throw $_.Exception.Message


### PR DESCRIPTION
## Summary

Fixes the **bad request** error reported in issue #107 for `Invoke-CPCPowerOn` and `Invoke-CPCPowerOff`.

## Root Cause

`Get-CloudPC -Name $Name` returns a **PowerShell array** (even when a single Cloud PC matches), not a scalar object. The original code used `$CloudPC.id` directly in string interpolation — when the array contains even one item, PowerShell's array-member enumeration produces the ID correctly on some builds but can silently produce a space-joined string or empty value on others, causing the Graph API to receive a malformed URL (e.g. `cloudPCs//powerOn` or `cloudPCs/id1 id2/powerOn`).

The same root cause was fixed for `Invoke-CPCChangeUserAccountType` in PR #106. This PR applies the identical fix to the two power-management functions.

## Changes

### `Invoke-CPCPowerOn.ps1`
- Wrap `Get-CloudPC` result in `@()` and check `.Count -eq 0` (handles both `$null` and empty array)
- Take `@($CloudPC)[0]` to guarantee a scalar before reading `.id`
- Add `-CloudPCId` parameter set for direct ID invocation (avoids the lookup entirely)
- Use named `$targetId` / `$targetName` variables for clarity

### `Invoke-CPCPowerOff.ps1`
- Same changes as above

## Testing



## References
- Fixes #107
- Same pattern applied in #106 (Invoke-CPCChangeUserAccountType)
- Graph API: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
- Graph API: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff

> **Note:** `PSCloudPC.psd1` is intentionally not modified — manifest updates are handled by the module owner.