### PR TITLE
Fix: Invoke-CPCPowerOn and Invoke-CPCPowerOff 400 Bad Request (closes #107)

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
@@ -37,8 +37,9 @@ function Invoke-CPCPowerOff {
             return
         }
 
-        # powerOff is a beta-only API; always use beta endpoint
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOff"
+        # powerOff is a beta-only API; always use beta endpoint.
+        # NOTE: The Graph API action name is all-lowercase (/poweroff), not camelCase.
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/poweroff"
 
         Write-Verbose "URL: $url"
     }

--- a/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
@@ -37,8 +37,9 @@ function Invoke-CPCPowerOn {
             return
         }
 
-        # powerOn is a beta-only API; always use beta endpoint
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/powerOn"
+        # powerOn is a beta-only API; always use beta endpoint.
+        # NOTE: The Graph API action name is all-lowercase (/poweron), not camelCase.
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$($CloudPC.id)/poweron"
 
         Write-Verbose "URL: $url"
     }


### PR DESCRIPTION
## Problem

Both `Invoke-CPCPowerOn` and `Invoke-CPCPowerOff` return **400 Bad Request** when called (issue #107).

## Root cause

The Microsoft Graph API action names in the URL path are **case-sensitive** and must be **all-lowercase**. The previous implementation used camelCase action names:

| Function | Old (broken) URL | Fixed URL |
|---|---|---|
| `Invoke-CPCPowerOn` | `.../cloudPCs/{id}/powerOn` | `.../cloudPCs/{id}/poweron` |
| `Invoke-CPCPowerOff` | `.../cloudPCs/{id}/powerOff` | `.../cloudPCs/{id}/poweroff` |

This is consistent with how other Graph API actions are documented — for example, `/reprovision`, `/reboot`, `/restore` are all lowercase in the official docs:
- https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
- https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff

## Changes

- `PSCloudPc/Public/Invoke-CPCPowerOn.ps1`: `powerOn` → `poweron` in the URL
- `PSCloudPc/Public/Invoke-CPCPowerOff.ps1`: `powerOff` → `poweroff` in the URL

No other logic was changed.

Closes #107