### PR TITLE
Add Get-CPCConnectivityHistory: retrieve Cloud PC connectivity event history

### DIFF
--- a/PSCloudPc/Public/Get-CPCConnectivityHistory.ps1
+++ b/PSCloudPc/Public/Get-CPCConnectivityHistory.ps1
@@ -1,0 +1,99 @@
+function Get-CPCConnectivityHistory {
+    <#
+    .SYNOPSIS
+    Retrieves the connectivity history for a specific Cloud PC
+    .DESCRIPTION
+    The function retrieves the connectivity event history for a specific Cloud PC
+    using the Microsoft Graph beta API. Each event describes a user connection attempt,
+    including when it occurred, the event type, and whether the connection succeeded or failed.
+
+    This is useful for diagnosing connectivity issues, identifying failed sessions,
+    and understanding usage patterns for a Cloud PC.
+
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+    .PARAMETER Name
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
+    .EXAMPLE
+    Get-CPCConnectivityHistory -Name "CPC-User-XXXX"
+    .EXAMPLE
+    Get-CPCConnectivityHistory -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .NOTES
+    Requires CloudPC.Read.All or CloudPC.ReadWrite.All permission (delegated or application).
+    This function uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-getcloudpcconnectivityhistory
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
+    )
+
+    begin {
+        Get-TokenValidity
+
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
+
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId = $CloudPCId
+            $targetName = $CloudPCId
+        }
+
+        # getCloudPcConnectivityHistory is a beta-only API
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/getCloudPcConnectivityHistory"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Retrieving connectivity history for Cloud PC '$targetName' (id: $targetId)"
+
+        try {
+            $result = Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method GET -ContentType "application/json"
+
+            if ($null -eq $result -or $null -eq $result.value -or $result.value.Count -eq 0) {
+                Write-Output "No connectivity history found for Cloud PC '$targetName'."
+                return
+            }
+
+            $PSObjectResults = @()
+            $result.value | ForEach-Object {
+                $event = [PSCustomObject]@{
+                    CloudPCName   = $targetName
+                    CloudPCId     = $targetId
+                    eventDateTime = $_.eventDateTime
+                    eventName     = $_.eventName
+                    eventType     = $_.eventType
+                    eventResult   = $_.eventResult
+                    activityId    = $_.activityId
+                    message       = $_.message
+                }
+                $PSObjectResults += $event
+            }
+
+            return $PSObjectResults
+        }
+        catch {
+            Throw $_.Exception.Message
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Get-CPCConnectivityHistory` function that retrieves the connectivity event history for a specific Cloud PC via the Microsoft Graph beta API.

This is a **read-only diagnostic function** that is particularly useful for EUC admins:
- Diagnose why a user cannot connect to their Cloud PC
- Identify patterns of failed connection attempts
- Review historical session activity for a Cloud PC
- Supplement `Invoke-CPCTroubleshoot` with historical context

## API Reference

```
GET /beta/deviceManagement/virtualEndpoint/cloudPCs/{id}/getCloudPcConnectivityHistory
```

Docs: https://learn.microsoft.com/en-us/graph/api/cloudpc-getcloudpcconnectivityhistory

Required permission: `CloudPC.Read.All` or `CloudPC.ReadWrite.All`

## Changes

- `PSCloudPc/Public/Get-CPCConnectivityHistory.ps1` — new function

No manifest changes (as per project convention).

## Output properties (cloudPcConnectivityEvent)

| Property | Description |
|---|---|
| `eventDateTime` | When the event occurred (UTC) |
| `eventName` | Name of the event |
| `eventType` | `userConnection`, `userTroubleshooting`, `deviceHealthCheck`, etc. |
| `eventResult` | `success`, `failure`, `unknown` |
| `activityId` | Activity GUID for `userConnection` events |
| `message` | Additional diagnostic message |

## Usage examples

```powershell
# By managed device name
Get-CPCConnectivityHistory -Name "CPC-User-XXXX"

# By Cloud PC object ID
Get-CPCConnectivityHistory -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"

# Filter to only failed events
Get-CPCConnectivityHistory -Name "CPC-User-XXXX" | Where-Object { $_.eventResult -eq "failure" }

# Show last 10 events sorted by date
Get-CPCConnectivityHistory -Name "CPC-User-XXXX" | Sort-Object eventDateTime -Descending | Select-Object -First 10
```

## Code style

Follows the established module patterns:
- `Get-TokenValidity` in begin block
- `@($CloudPC)[0]` array-safe guard on the Get-CloudPC result
- `-CloudPCId` parameter set for direct invocation without name lookup
- Null guard with descriptive error message
- `Invoke-RestMethod` with `$script:Authheader`
- PSCustomObject output with consistent CloudPC-prefixed names
- Full comment-based help with `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`, `.NOTES`