### PR TITLE
Add Invoke-CPCRetryPartnerAgentInstallation: retry failed partner agent installation on a Cloud PC

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCRetryPartnerAgentInstallation.ps1
+++ b/PSCloudPc/Public/Invoke-CPCRetryPartnerAgentInstallation.ps1
@@ -1,0 +1,85 @@
+function Invoke-CPCRetryPartnerAgentInstallation {
+    <#
+    .SYNOPSIS
+    Retries installation of partner agents that failed to install on a Cloud PC
+    .DESCRIPTION
+    The function triggers the retryPartnerAgentInstallation action on a specific Cloud PC.
+    When third-party partner agents (such as monitoring or security agents) fail to install
+    during provisioning, this action instructs the service to retry the failed agent
+    installations without requiring a full reprovision.
+
+    This is useful when a Cloud PC enters a warning or degraded state because a partner
+    agent could not be installed, and you want to attempt remediation before resorting
+    to reprovisioning.
+
+    The action returns 204 No Content on success. You can identify the target Cloud PC
+    by its managed device name (default) or by providing the Cloud PC object ID directly
+    via -CloudPCId.
+    .PARAMETER Name
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
+    .EXAMPLE
+    Invoke-CPCRetryPartnerAgentInstallation -Name "CPC-User-XXXX"
+    .EXAMPLE
+    Invoke-CPCRetryPartnerAgentInstallation -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .EXAMPLE
+    Invoke-CPCRetryPartnerAgentInstallation -Name "CPC-User-XXXX" -WhatIf
+    .NOTES
+    Requires CloudPC.ReadWrite.All permission (delegated or application).
+    This function uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-retrypartneragentinstallation
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
+
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId = $CloudPCId
+            $targetName = $CloudPCId
+        }
+
+        # retryPartnerAgentInstallation is a beta-only API
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/retryPartnerAgentInstallation"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Retrying partner agent installation on Cloud PC '$targetName' (id: $targetId)"
+
+        if ($PSCmdlet.ShouldProcess($targetName, "Retry partner agent installation on Cloud PC")) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -ContentType "application/json"
+                Write-Output "Partner agent installation retry triggered for Cloud PC '$targetName'"
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Invoke-CPCRetryPartnerAgentInstallation`, a new function that triggers the Graph beta [`retryPartnerAgentInstallation`](https://learn.microsoft.com/en-us/graph/api/cloudpc-retrypartneragentinstallation?view=graph-rest-beta) action on a Cloud PC.

## Why

When a Windows 365 Cloud PC is provisioned, third-party partner agents (monitoring, security, endpoint management) are installed as part of the process. If any of these agent installations fail, the Cloud PC may enter a warning or degraded state — even though the machine itself is otherwise functional. Without this function, the only documented remediation path is a full reprovision.

This action instructs the service to selectively retry the failed agent installations without touching the OS or user data, making it a much lighter-weight recovery option.

## What changed

- **New file:** `PSCloudPc/Public/Invoke-CPCRetryPartnerAgentInstallation.ps1`
  - Two parameter sets: `-Name` (managed device name lookup via `Get-CloudPC`) and `-CloudPCId` (direct ID, skips lookup)
  - Array-safe `Get-CloudPC` guard (`@(...)[0]`) consistent with `Invoke-CPCPowerOn/Off` and `Invoke-CPCChangeUserAccountType`
  - `SupportsShouldProcess` for `-WhatIf` / `-Confirm` support
  - Null guard with a clear `Throw` message
  - Hardcoded `/beta/` path since this action does not yet exist in v1.0
  - Full comment-based help with `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`, `.NOTES`

## Code style

The implementation mirrors `Invoke-CPCTroubleshoot` (the closest analog — a no-body POST action that returns 204) and adopts the `-CloudPCId` parameter set pattern introduced in `Invoke-CPCPowerOn/Off`.

## How to test

```powershell
# Dry run (no API call made)
Invoke-CPCRetryPartnerAgentInstallation -Name "CPC-User-XXXX" -WhatIf

# By name
Invoke-CPCRetryPartnerAgentInstallation -Name "CPC-User-XXXX"

# By ID (useful in automation scripts)
Invoke-CPCRetryPartnerAgentInstallation -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
```

On success the Graph API returns `204 No Content`. The function outputs a confirmation message.

## API reference

- https://learn.microsoft.com/en-us/graph/api/cloudpc-retrypartneragentinstallation?view=graph-rest-beta

## Notes

- Beta-only endpoint; there is no v1.0 equivalent at time of writing.
- `PSCloudPC.psd1` is intentionally **not modified** — manifest updates are handled by the maintainer.