### PR TITLE
Add Get-CPCRealTimeConnectionStatus: live remote connection status via Graph beta

### DIFF
--- a/PSCloudPc/Public/Get-CPCRealTimeConnectionStatus.ps1
+++ b/PSCloudPc/Public/Get-CPCRealTimeConnectionStatus.ps1
@@ -1,0 +1,97 @@
+function Get-CPCRealTimeConnectionStatus {
+    <#
+    .SYNOPSIS
+    Retrieves the real-time remote connection status for a specific Cloud PC
+    .DESCRIPTION
+    The function retrieves live connection status for a specific Cloud PC using the
+    Microsoft Graph beta cloudPcReports getRealTimeRemoteConnectionStatus API.
+
+    Unlike Get-CPCConnectivityHistory (which shows historical events), this function
+    returns the current state: whether a user is actively signed in, how long the
+    session has been running, and days since last use. Useful for live helpdesk
+    troubleshooting and monitoring dashboards.
+
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+    .PARAMETER Name
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
+    .EXAMPLE
+    Get-CPCRealTimeConnectionStatus -Name "CPC-User-XXXX"
+    .EXAMPLE
+    Get-CPCRealTimeConnectionStatus -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .EXAMPLE
+    # Check all Cloud PCs and show only those with active sessions
+    Get-CloudPC | ForEach-Object { Get-CPCRealTimeConnectionStatus -CloudPCId $_.id } |
+        Where-Object { $_.signInStatus -eq 'signedIn' }
+    .NOTES
+    Requires CloudPC.Read.All or CloudPC.ReadWrite.All permission (delegated or application).
+    This function uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpcreports-getrealtimeremoteconnectionstatus?view=graph-rest-beta
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
+
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            $CloudPC = @($CloudPC)[0]
+            $targetId = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId = $CloudPCId
+            $targetName = $CloudPCId
+        }
+
+        # getRealTimeRemoteConnectionStatus is a beta-only OData function on the reports resource
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/reports/getRealTimeRemoteConnectionStatus(cloudPcId='$targetId')"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Retrieving real-time connection status for Cloud PC '$targetName' (id: $targetId)"
+
+        try {
+            $result = Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method GET -ContentType "application/json"
+
+            if ($null -eq $result) {
+                Write-Output "No real-time connection status returned for Cloud PC '$targetName'."
+                return
+            }
+
+            [PSCustomObject]@{
+                CloudPCName       = $targetName
+                CloudPCId         = $targetId
+                signInStatus      = $result.signInStatus
+                daysSinceLastUse  = $result.daysSinceLastUse
+                signInDateTime    = $result.signInDateTime
+                signOutDateTime   = $result.signOutDateTime
+                durationInSeconds = $result.durationInSeconds
+                usageStatus       = $result.usageStatus
+            }
+        }
+        catch {
+            Throw $_.Exception.Message
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Get-CPCRealTimeConnectionStatus` — a new read-only diagnostic function that retrieves the **live** remote connection status of a Cloud PC using the Microsoft Graph beta `cloudPcReports: getRealTimeRemoteConnectionStatus` API.

## Why

The existing `Get-CPCConnectivityHistory` function returns historical connection events (flushed from the backend log). Helpdesk staff and monitoring scripts often need to know **right now** whether a user is actively connected, how long their session has been running, or how many days since the machine was last used. This function fills that gap.

Use cases:
- Live helpdesk: "Is the user currently connected to their Cloud PC?"
- Idle detection: find Cloud PCs unused for N days via `daysSinceLastUse`
- Session auditing: capture `signInDateTime` and `durationInSeconds` for SLA reporting

## API Reference

- **Endpoint:** `GET /beta/deviceManagement/virtualEndpoint/reports/getRealTimeRemoteConnectionStatus(cloudPcId='{id}')`
- **Permissions:** `CloudPC.Read.All` or `CloudPC.ReadWrite.All`
- **Docs:** https://learn.microsoft.com/en-us/graph/api/cloudpcreports-getrealtimeremoteconnectionstatus?view=graph-rest-beta

## Changes

- Added `PSCloudPc/Public/Get-CPCRealTimeConnectionStatus.ps1`
- No manifest changes (maintainer handles `FunctionsToExport`)

## Usage

```powershell
# Get live status by managed device name
Get-CPCRealTimeConnectionStatus -Name "CPC-User-XXXX"

# Get live status by Cloud PC ID
Get-CPCRealTimeConnectionStatus -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"

# Find all Cloud PCs with active sessions
Get-CloudPC | ForEach-Object { Get-CPCRealTimeConnectionStatus -CloudPCId $_.id } |
    Where-Object { $_.signInStatus -eq 'signedIn' }

# Find Cloud PCs unused for more than 30 days
Get-CloudPC | ForEach-Object { Get-CPCRealTimeConnectionStatus -CloudPCId $_.id } |
    Where-Object { $_.daysSinceLastUse -gt 30 }
```

## Output

| Property | Description |
|---|---|
| `CloudPCName` | Managed device display name |
| `CloudPCId` | Cloud PC object ID |
| `signInStatus` | Current sign-in state (`signedIn` / `signedOut`) |
| `daysSinceLastUse` | Number of days since the last user session |
| `signInDateTime` | Timestamp of the current or most recent sign-in |
| `signOutDateTime` | Timestamp of the most recent sign-out (null if signed in) |
| `durationInSeconds` | Duration of the current or most recent session in seconds |
| `usageStatus` | Usage classification returned by the API |

## Code Style

Follows the pattern established in `Get-CPCConnectivityHistory` and `Get-CPCRemoteActionResult`:
- `DefaultParameterSetName = 'Name'` with `-Name`/`-CloudPCId` parameter sets
- `Get-TokenValidity` in `Begin` block
- Array-safe `@($CloudPC).Count -eq 0` guard
- `Invoke-RestMethod` with `$script:Authheader`
- `PSCustomObject` output for pipeline compatibility
- `try/catch` with `Throw $_.Exception.Message`
- Comment-based help with `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`, `.NOTES`
