### PR TITLE
Fix Invoke-CPCPowerOn/Off: lowercase URL path + Content-Type header (closes #107)

### DIFF
--- a/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOff.ps1
@@ -60,7 +60,11 @@ function Invoke-CPCPowerOff {
             $targetName = $CloudPCId
         }
 
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/powerOff"
+        # poweroff is a beta-only API; always use beta endpoint.
+        # The Graph API action name is all-lowercase (/poweroff), not camelCase (/powerOff).
+        # Content-Type must be set to application/json even for body-less POST actions
+        # to avoid a 400 Bad Request response from the Graph API.
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/poweroff"
 
         Write-Verbose "URL: $url"
     }
@@ -70,7 +74,7 @@ function Invoke-CPCPowerOff {
 
         if ($PSCmdlet.ShouldProcess($targetName, "Power off Cloud PC")) {
             try {
-                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -ContentType "application/json"
                 Write-Output "Cloud PC '$targetName' power off initiated"
             }
             catch {

--- a/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
+++ b/PSCloudPc/Public/Invoke-CPCPowerOn.ps1
@@ -59,8 +59,12 @@ function Invoke-CPCPowerOn {
             $targetId   = $CloudPCId
             $targetName = $CloudPCId
         }
-        
-        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/powerOn"
+
+        # poweron is a beta-only API; always use beta endpoint.
+        # The Graph API action name is all-lowercase (/poweron), not camelCase (/powerOn).
+        # Content-Type must be set to application/json even for body-less POST actions
+        # to avoid a 400 Bad Request response from the Graph API.
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/poweron"
 
         Write-Verbose "URL: $url"
     }
@@ -70,7 +74,7 @@ function Invoke-CPCPowerOn {
 
         if ($PSCmdlet.ShouldProcess($targetName, "Power on Cloud PC")) {
             try {
-                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -ContentType "application/json"
                 Write-Output "Cloud PC '$targetName' power on initiated"
             }
             catch {


### PR DESCRIPTION
## Summary

Fixes the persistent `400 Bad Request` error in `Invoke-CPCPowerOn` and `Invoke-CPCPowerOff` (issue #107).

Two root causes were identified and fixed in this PR:

---

### Fix 1: URL path case sensitivity

The Microsoft Graph API action endpoints are **case-sensitive** and require **all-lowercase** action names. The current `develop` branch uses camelCase which triggers a `400 Bad Request`:

| Function | Before (broken) | After (correct) |
|---|---|---|
| `Invoke-CPCPowerOn` | `.../cloudPCs/{id}/powerOn` | `.../cloudPCs/{id}/poweron` |
| `Invoke-CPCPowerOff` | `.../cloudPCs/{id}/powerOff` | `.../cloudPCs/{id}/poweroff` |

This fix was originally applied in PR #109 but was inadvertently overwritten during a subsequent merge.

### Fix 2: Missing `Content-Type` header

Microsoft Graph POST action endpoints return `400 Bad Request` when no `Content-Type` header is supplied, even if the request body is empty. Added `-ContentType "application/json"` to both `Invoke-RestMethod` calls — consistent with other action functions in the module (e.g. `Invoke-CPCRetryPartnerAgentInstallation`, `Invoke-CPCChangeUserAccountType`).

---

## Files changed

- `PSCloudPc/Public/Invoke-CPCPowerOn.ps1`
- `PSCloudPc/Public/Invoke-CPCPowerOff.ps1`

## How to test

```powershell
# Requires a Windows 365 Frontline Cloud PC

Invoke-CPCPowerOff -Name "CPC-FrontlineUser-XXXX"
# Expected: "Cloud PC CPC-FrontlineUser-XXXX power off initiated"

Invoke-CPCPowerOn -Name "CPC-FrontlineUser-XXXX"
# Expected: "Cloud PC CPC-FrontlineUser-XXXX power on initiated"

# Also works with direct ID:
Invoke-CPCPowerOff -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
```

## References

- Closes #107
- Graph API docs: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweron
- Graph API docs: https://learn.microsoft.com/en-us/graph/api/cloudpc-poweroff