### PR TITLE
Add Get-CPCReviewStatus and Set-CPCReviewStatus: Cloud PC security review management

### DIFF
--- a/PSCloudPc/Public/Get-CPCReviewStatus.ps1
+++ b/PSCloudPc/Public/Get-CPCReviewStatus.ps1
@@ -1,0 +1,102 @@
+function Get-CPCReviewStatus {
+    <#
+    .SYNOPSIS
+    Retrieves the review status of a Cloud PC
+    .DESCRIPTION
+    The function retrieves the current review status of a specific Cloud PC using the
+    Microsoft Graph beta API. Use this to check whether a Cloud PC has been marked
+    "in review" by an administrator (for example, when the device is suspected of
+    being compromised or involved in a security incident).
+
+    The review status includes whether the device is in review, the access level
+    applied to the end user, the time the review started, and details about any
+    linked Azure Storage snapshot.
+
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+    .PARAMETER Name
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
+    .EXAMPLE
+    Get-CPCReviewStatus -Name "CPC-User-XXXX"
+    .EXAMPLE
+    Get-CPCReviewStatus -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd"
+    .EXAMPLE
+    # Check review status for all Cloud PCs and show those that are in review
+    Get-CloudPC | ForEach-Object { Get-CPCReviewStatus -CloudPCId $_.id } |
+        Where-Object { $_.inReview -eq $true }
+    .NOTES
+    Requires CloudPC.Read.All or CloudPC.ReadWrite.All permission (delegated or application).
+    This function uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-retrievereviewstatus
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId
+    )
+
+    begin {
+        Get-TokenValidity
+
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
+
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId   = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId   = $CloudPCId
+            $targetName = $CloudPCId
+        }
+
+        # retrieveReviewStatus is a beta-only GET action on the Cloud PC resource
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/retrieveReviewStatus"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        Write-Verbose "Retrieving review status for Cloud PC '$targetName' (id: $targetId)"
+
+        try {
+            $result = Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method GET -ContentType "application/json"
+        }
+        catch {
+            Throw $_.Exception.Message
+        }
+
+        if ($null -eq $result) {
+            Write-Output "No review status returned for Cloud PC '$targetName'."
+            return
+        }
+
+        [PSCustomObject]@{
+            CloudPCName                = $targetName
+            CloudPCId                  = $targetId
+            inReview                   = $result.inReview
+            userAccessLevel            = $result.userAccessLevel
+            reviewStartDateTime        = $result.reviewStartDateTime
+            restorePointDateTime       = $result.restorePointDateTime
+            subscriptionId             = $result.subscriptionId
+            subscriptionName           = $result.subscriptionName
+            azureStorageAccountId      = $result.azureStorageAccountId
+            azureStorageAccountName    = $result.azureStorageAccountName
+            azureStorageContainerName  = $result.azureStorageContainerName
+        }
+    }
+}

--- a/PSCloudPc/Public/Set-CPCReviewStatus.ps1
+++ b/PSCloudPc/Public/Set-CPCReviewStatus.ps1
@@ -1,0 +1,131 @@
+function Set-CPCReviewStatus {
+    <#
+    .SYNOPSIS
+    Sets the review status of a Cloud PC to flag it as suspicious or clear it
+    .DESCRIPTION
+    The function sets the review status of a specific Cloud PC using the Microsoft
+    Graph beta API. Use this to mark a Cloud PC as "in review" when you suspect
+    it has been compromised or is involved in a security incident. When a Cloud PC
+    is placed in review, you can optionally restrict end-user access and capture a
+    snapshot to an Azure Storage account for forensic analysis.
+
+    Once the investigation is complete, use this function again with -InReview:$false
+    to return the Cloud PC to a normal state and restore full user access.
+
+    You can identify the target Cloud PC by its managed device name (default) or
+    by providing the Cloud PC object ID directly via -CloudPCId.
+    .PARAMETER Name
+    The managed device name of the Cloud PC. Use Get-CloudPC to find Cloud PC names.
+    Mutually exclusive with -CloudPCId.
+    .PARAMETER CloudPCId
+    The object ID (GUID) of the Cloud PC. Use Get-CloudPC to find Cloud PC IDs.
+    Mutually exclusive with -Name.
+    .PARAMETER InReview
+    Set to $true to place the Cloud PC in review (suspicious). Set to $false to
+    clear the review and return to normal state. Default: $true.
+    .PARAMETER UserAccessLevel
+    The access level to apply to the end user while the Cloud PC is in review.
+    Valid values: 'unrestricted' (user retains full access), 'restricted' (user
+    access is limited). Default: 'restricted'.
+    Only applicable when -InReview is $true.
+    .PARAMETER AzureStorageAccountId
+    Optional. The resource ID of the Azure Storage account where the Cloud PC
+    snapshot will be saved for forensic analysis. Use the full ARM resource ID:
+    /subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{name}
+    .EXAMPLE
+    Set-CPCReviewStatus -Name "CPC-User-XXXX"
+    Places the Cloud PC in review with restricted user access (default behaviour).
+    .EXAMPLE
+    Set-CPCReviewStatus -CloudPCId "4b5ad5e0-6a0b-4ffc-818d-36bb23cf4dbd" -InReview $true -UserAccessLevel restricted
+    .EXAMPLE
+    Set-CPCReviewStatus -Name "CPC-User-XXXX" -InReview $false
+    Clears the review status and returns the Cloud PC to normal operation.
+    .EXAMPLE
+    Set-CPCReviewStatus -Name "CPC-User-XXXX" -InReview $true -UserAccessLevel restricted `
+        -AzureStorageAccountId "/subscriptions/f68bd846-16ad-4b51-a7c6-c84944a3367c/resourceGroups/ForensicRG/providers/Microsoft.Storage/storageAccounts/forensicstorage"
+    .EXAMPLE
+    Set-CPCReviewStatus -Name "CPC-User-XXXX" -WhatIf
+    .NOTES
+    Requires CloudPC.ReadWrite.All permission (delegated or application).
+    This function uses the Microsoft Graph beta endpoint.
+    API reference: https://learn.microsoft.com/en-us/graph/api/cloudpc-setreviewstatus
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Name', SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$CloudPCId,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$InReview = $true,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('unrestricted', 'restricted')]
+        [string]$UserAccessLevel = 'restricted',
+
+        [Parameter(Mandatory = $false)]
+        [string]$AzureStorageAccountId
+    )
+
+    begin {
+        Get-TokenValidity
+
+        if ($PSCmdlet.ParameterSetName -eq 'Name') {
+            $CloudPC = Get-CloudPC -Name $Name
+
+            if ($null -eq $CloudPC -or @($CloudPC).Count -eq 0) {
+                Throw "No Cloud PC found with name '$Name'. Use Get-CloudPC to verify the managed device name."
+            }
+
+            # Take the first result in case the filter returns multiple
+            $CloudPC = @($CloudPC)[0]
+            $targetId   = $CloudPC.id
+            $targetName = $CloudPC.displayName
+        }
+        else {
+            $targetId   = $CloudPCId
+            $targetName = $CloudPCId
+        }
+
+        # setReviewStatus is a beta-only POST action on the Cloud PC resource
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/cloudPCs/$targetId/setReviewStatus"
+
+        Write-Verbose "URL: $url"
+    }
+
+    Process {
+        # Build the reviewStatus body
+        $reviewStatus = @{
+            inReview        = $InReview
+            userAccessLevel = $UserAccessLevel
+        }
+
+        if ($PSBoundParameters.ContainsKey('AzureStorageAccountId') -and -not [string]::IsNullOrWhiteSpace($AzureStorageAccountId)) {
+            $reviewStatus['azureStorageAccountId'] = $AzureStorageAccountId
+        }
+
+        $body = @{ reviewStatus = $reviewStatus } | ConvertTo-Json -Depth 10
+
+        $action = if ($InReview) { "Mark as in-review (userAccessLevel=$UserAccessLevel)" } else { "Clear review status" }
+        Write-Verbose "Setting review status on Cloud PC '$targetName' (id: $targetId): InReview=$InReview, UserAccessLevel=$UserAccessLevel"
+
+        if ($PSCmdlet.ShouldProcess($targetName, $action)) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -Body $body -ContentType "application/json"
+                if ($InReview) {
+                    Write-Output "Cloud PC '$targetName' has been placed in review with access level '$UserAccessLevel'."
+                }
+                else {
+                    Write-Output "Cloud PC '$targetName' review status cleared. Device returned to normal state."
+                }
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two companion functions for Cloud PC security review management:

- **`Get-CPCReviewStatus`** — retrieve the current review status of a Cloud PC
- **`Set-CPCReviewStatus`** — place a Cloud PC in review (or clear it) when suspected of compromise

---

## Motivation

The Microsoft Graph beta API has provided `setReviewStatus` and `retrieveReviewStatus` actions on the Cloud PC resource for some time, but PSCloudPC has no coverage of these security-focused operations. When a Cloud PC is suspected of compromise or insider threat, admins need a programmatic way to:

1. Flag the device as under investigation
2. Optionally restrict end-user access while the review is in progress
3. Optionally capture a forensic snapshot to an Azure Storage account
4. Check the review state of any Cloud PC
5. Clear the review once investigation is complete

Without these functions, admins must fall back to the Microsoft Intune admin center UI for every step — not practical at scale or in automated runbooks.

---

## New functions

### `Get-CPCReviewStatus`

Calls `GET /beta/deviceManagement/virtualEndpoint/cloudPCs/{id}/retrieveReviewStatus` and returns a typed `PSCustomObject` with:

| Property | Description |
|---|---|
| `CloudPCName` / `CloudPCId` | Identifier |
| `inReview` | `$true` if the device is flagged for review |
| `userAccessLevel` | `unrestricted` or `restricted` |
| `reviewStartDateTime` | When the review was opened |
| `restorePointDateTime` | Snapshot capture time |
| `subscriptionId` / `subscriptionName` | Azure subscription for the snapshot |
| `azureStorageAccountId` / `azureStorageAccountName` / `azureStorageContainerName` | Storage details |

Supports `-Name` (managed device name) and `-CloudPCId` parameter sets, consistent with all other PSCloudPC functions.

### `Set-CPCReviewStatus`

Calls `POST /beta/deviceManagement/virtualEndpoint/cloudPCs/{id}/setReviewStatus` with a `reviewStatus` body. Parameters:

| Parameter | Description |
|---|---|
| `-Name` / `-CloudPCId` | Target Cloud PC |
| `-InReview` | `$true` to open review, `$false` to close (default: `$true`) |
| `-UserAccessLevel` | `restricted` (default) or `unrestricted` |
| `-AzureStorageAccountId` | Optional ARM resource ID for forensic snapshot storage |

Supports `SupportsShouldProcess` (`-WhatIf` / `-Confirm`).

---

## Usage examples

```powershell
# Flag a suspicious Cloud PC — restrict user, capture forensic snapshot
Set-CPCReviewStatus -Name "CPC-User-XXXX" -InReview $true -UserAccessLevel restricted `
    -AzureStorageAccountId "/subscriptions/f68.../resourceGroups/ForensicRG/providers/Microsoft.Storage/storageAccounts/forensicstorage"

# Check the review state of a Cloud PC
Get-CPCReviewStatus -Name "CPC-User-XXXX"

# Find ALL Cloud PCs currently in review
Get-CloudPC | ForEach-Object { Get-CPCReviewStatus -CloudPCId $_.id } |
    Where-Object { $_.inReview -eq $true }

# Clear review once investigation is complete
Set-CPCReviewStatus -Name "CPC-User-XXXX" -InReview $false
```

---

## API references

- [cloudPC: setReviewStatus](https://learn.microsoft.com/en-us/graph/api/cloudpc-setreviewstatus?view=graph-rest-beta)
- [cloudPC: retrieveReviewStatus](https://learn.microsoft.com/en-us/graph/api/cloudpc-retrievereviewstatus?view=graph-rest-beta)
- [cloudPcReviewStatus resource type](https://learn.microsoft.com/en-us/graph/api/resources/cloudpcreviewstatus?view=graph-rest-beta)

---

## Code style

Both functions follow the established PSCloudPC patterns:
- `Get-TokenValidity` in `begin` block
- `-Name` / `-CloudPCId` parameter sets with `ValidateNotNullOrEmpty`
- Array-safe `@($CloudPC)[0]` guard for `Get-CloudPC` results
- `Invoke-RestMethod` with `$script:Authheader`
- `SupportsShouldProcess` on the write function
- Consistent comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`, `.NOTES`)
