### PR TITLE
Add: Get/New/Remove-CPCMaintenanceWindow - Cloud PC maintenance window CRUD (closes #46)

### DIFF
--- a/PSCloudPc/Public/Get-CPCMaintenanceWindow.ps1
+++ b/PSCloudPc/Public/Get-CPCMaintenanceWindow.ps1
@@ -1,0 +1,60 @@
+function Get-CPCMaintenanceWindow {
+    <#
+    .SYNOPSIS
+    Returns Cloud PC Maintenance Windows
+    .DESCRIPTION
+    The function will return all Cloud PC Maintenance Windows or a specific one filtered by display name.
+    Maintenance windows define scheduled time slots during which Cloud PC resize and other operations
+    may run to minimise disruption to end users.
+    .PARAMETER Name
+    Enter the display name of the Cloud PC Maintenance Window to retrieve
+    .EXAMPLE
+    Get-CPCMaintenanceWindow
+    .EXAMPLE
+    Get-CPCMaintenanceWindow -Name "Business Hours Window"
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(ParameterSetName = "Name")]
+        [string]$Name
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        switch ($PsCmdlet.ParameterSetName) {
+            Name {
+                Write-Verbose "Name parameter provided"
+                $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/maintenanceWindows?`$filter=displayName+eq+'$($Name)'"
+            }
+            default {
+                $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/maintenanceWindows"
+            }
+        }
+    }
+
+    Process {
+        Write-Verbose $url
+        $result = Invoke-WebRequest -Uri $url -Method GET -Headers $script:authHeader -SkipHttpErrorCheck
+
+        if ($null -eq $result) {
+            Write-Error "No Maintenance Windows returned"
+            return
+        }
+
+        $resultnew = $result.Content | ConvertFrom-Json
+        $returnResults = @()
+        $resultnew.value | ForEach-Object {
+
+            $Info = [PSCustomObject]@{
+                id                            = $_.id
+                displayName                   = $_.displayName
+                description                   = $_.description
+                notificationLeadTimeInMinutes = $_.notificationLeadTimeInMinutes
+                schedules                     = $_.schedules
+            }
+            $returnResults += $Info
+        }
+        return $returnResults
+    }
+}

--- a/PSCloudPc/Public/New-CPCMaintenanceWindow.ps1
+++ b/PSCloudPc/Public/New-CPCMaintenanceWindow.ps1
@@ -1,0 +1,112 @@
+function New-CPCMaintenanceWindow {
+    <#
+    .SYNOPSIS
+    Creates a new Cloud PC Maintenance Window
+    .DESCRIPTION
+    The function will create a new Cloud PC Maintenance Window via the Microsoft Graph beta API.
+    A maintenance window defines a recurring time slot (weekday and/or weekend) during which
+    scheduled Cloud PC operations such as resizes may be performed with advance notice to users.
+    .PARAMETER DisplayName
+    The display name of the new maintenance window
+    .PARAMETER Description
+    Optional description for the maintenance window
+    .PARAMETER NotificationLeadTimeInMinutes
+    Number of minutes before the maintenance window opens that end users are notified.
+    Defaults to 60.
+    .PARAMETER WeekdayStartTime
+    Start time of the weekday maintenance schedule in HH:MM format (24-hour), e.g. "01:00"
+    .PARAMETER WeekdayEndTime
+    End time of the weekday maintenance schedule in HH:MM format (24-hour), e.g. "05:00"
+    .PARAMETER WeekendStartTime
+    Optional start time of the weekend maintenance schedule in HH:MM format (24-hour).
+    If omitted, no weekend schedule is created.
+    .PARAMETER WeekendEndTime
+    Optional end time of the weekend maintenance schedule in HH:MM format (24-hour).
+    Required when WeekendStartTime is specified.
+    .EXAMPLE
+    New-CPCMaintenanceWindow -DisplayName "Off-Hours Window" -WeekdayStartTime "01:00" -WeekdayEndTime "05:00"
+    .EXAMPLE
+    New-CPCMaintenanceWindow -DisplayName "Extended Window" -Description "Weekday and weekend coverage" -NotificationLeadTimeInMinutes 120 -WeekdayStartTime "02:00" -WeekdayEndTime "06:00" -WeekendStartTime "01:00" -WeekendEndTime "08:00"
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Description,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 1440)]
+        [int]$NotificationLeadTimeInMinutes = 60,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^\d{2}:\d{2}$')]
+        [string]$WeekdayStartTime,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^\d{2}:\d{2}$')]
+        [string]$WeekdayEndTime,
+
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^\d{2}:\d{2}$')]
+        [string]$WeekendStartTime,
+
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^\d{2}:\d{2}$')]
+        [string]$WeekendEndTime
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/maintenanceWindows"
+        Write-Verbose "URL for API request: $url"
+
+        $existing = Get-CPCMaintenanceWindow -Name $DisplayName -ErrorAction SilentlyContinue
+        if ($existing) {
+            Write-Error "A Cloud PC Maintenance Window with the name '$DisplayName' already exists"
+            return
+        }
+    }
+
+    Process {
+        $schedules = @(
+            @{
+                scheduleType = "weekday"
+                startTime    = "$($WeekdayStartTime):00.0000000"
+                endTime      = "$($WeekdayEndTime):00.0000000"
+            }
+        )
+
+        if ($PSBoundParameters.ContainsKey('WeekendStartTime') -and $PSBoundParameters.ContainsKey('WeekendEndTime')) {
+            $schedules += @{
+                scheduleType = "weekend"
+                startTime    = "$($WeekendStartTime):00.0000000"
+                endTime      = "$($WeekendEndTime):00.0000000"
+            }
+        }
+
+        $params = @{
+            displayName                   = $DisplayName
+            notificationLeadTimeInMinutes = $NotificationLeadTimeInMinutes
+            schedules                     = $schedules
+        }
+
+        if ($PSBoundParameters.ContainsKey('Description')) {
+            $params['description'] = $Description
+        }
+
+        $body = $params | ConvertTo-Json -Depth 10
+        Write-Verbose "Body: $body"
+
+        if ($PSCmdlet.ShouldProcess($DisplayName, 'New Cloud PC Maintenance Window')) {
+            try {
+                Invoke-RestMethod -Headers $script:Authheader -Uri $url -Method POST -ContentType "application/json" -Body $body
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}

--- a/PSCloudPc/Public/Remove-CPCMaintenanceWindow.ps1
+++ b/PSCloudPc/Public/Remove-CPCMaintenanceWindow.ps1
@@ -1,0 +1,43 @@
+function Remove-CPCMaintenanceWindow {
+    <#
+    .SYNOPSIS
+    Removes a Cloud PC Maintenance Window
+    .DESCRIPTION
+    The function will remove a Cloud PC Maintenance Window by display name using the Microsoft Graph beta API.
+    .PARAMETER Name
+    Enter the display name of the Cloud PC Maintenance Window to remove
+    .EXAMPLE
+    Remove-CPCMaintenanceWindow -Name "Off-Hours Window"
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    Begin {
+        Get-TokenValidity
+
+        $MaintenanceWindow = Get-CPCMaintenanceWindow -Name $Name
+
+        if ($null -eq $MaintenanceWindow) {
+            Write-Error "No Cloud PC Maintenance Window found with name '$Name'"
+            return
+        }
+
+        $url = "https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/maintenanceWindows/$($MaintenanceWindow.id)"
+        Write-Verbose "Delete URL: $url"
+    }
+
+    Process {
+        if ($PSCmdlet.ShouldProcess($Name, 'Remove Cloud PC Maintenance Window')) {
+            try {
+                Write-Verbose "Removing Cloud PC Maintenance Window '$Name'"
+                Invoke-WebRequest -Uri $url -Method DELETE -Headers $script:authHeader -SkipHttpErrorCheck
+            }
+            catch {
+                Throw $_.Exception.Message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Cloud PC Maintenance Window management (Get, New, Remove) via the Microsoft Graph beta API, closing the long-standing feature request in #46.

### New functions

| Function | Description |
|---|---|
| `Get-CPCMaintenanceWindow` | Lists all maintenance windows, or filters by display name |
| `New-CPCMaintenanceWindow` | Creates a maintenance window with weekday (and optional weekend) schedule |
| `Remove-CPCMaintenanceWindow` | Deletes a maintenance window by display name |

### API reference

All three functions target the beta endpoint:

```
GET/POST/DELETE /beta/deviceManagement/virtualEndpoint/maintenanceWindows[/{id}]
```

Required permission scope: `CloudPC.ReadWrite.All`

Official documentation: https://learn.microsoft.com/en-us/graph/api/resources/cloudpc-api-overview?view=graph-rest-beta

### Usage examples

```powershell
# List all maintenance windows
Get-CPCMaintenanceWindow

# Get a specific window
Get-CPCMaintenanceWindow -Name "Off-Hours Window"

# Create a weekday-only window with 2-hour lead notification
New-CPCMaintenanceWindow -DisplayName "Off-Hours Window" \
    -Description "Weekday late-night resize slot" \
    -NotificationLeadTimeInMinutes 120 \
    -WeekdayStartTime "01:00" -WeekdayEndTime "05:00"

# Create a window covering both weekdays and weekends
New-CPCMaintenanceWindow -DisplayName "Extended Window" \
    -WeekdayStartTime "02:00" -WeekdayEndTime "06:00" \
    -WeekendStartTime "01:00" -WeekendEndTime "08:00"

# Remove a maintenance window
Remove-CPCMaintenanceWindow -Name "Off-Hours Window"
```

### Design notes

- Functions follow the established module style: `Get-TokenValidity` in `Begin`, `Invoke-WebRequest`/`Invoke-RestMethod` with `$script:authHeader`/`$script:Authheader`, `PSCustomObject` output, `SupportsShouldProcess` on mutations
- API is beta-only — URLs are hardcoded with `/beta/` (no `$script:MSGraphVersion` substitution)
- Schedule times accepted as `HH:MM` strings and converted to the API's `HH:MM:SS.0000000` format automatically
- Duplicate-name guard in `New-CPCMaintenanceWindow` calls `Get-CPCMaintenanceWindow` before POSTing
- A future `Update-CPCMaintenanceWindow` (PATCH) can follow in a subsequent PR

Closes #46
